### PR TITLE
dark color theme acscommandcenter

### DIFF
--- a/ExtProd/INSTALL/buildJTattoo
+++ b/ExtProd/INSTALL/buildJTattoo
@@ -1,0 +1,35 @@
+#! /bin/bash
+#
+# who       when        what
+# --------  ----------  ----------------------------------------------
+# ssarris  2020-04-29  new script 
+#
+
+# Load functions
+. standardUtilities
+#
+# Fetch operating system and release version
+#
+os_discovery
+
+
+LOG=buildJTattoo.log
+#
+exec > $LOG 2>&1
+
+date
+
+if [ ! -e ../PRODUCTS/JTattoo-1.6.13.jar ]
+then
+  echo Error: JTattoo-1.6.13.jar missing
+  exit 2
+fi
+
+CWD=`pwd`
+cd ../PRODUCTS
+echo Copy JTattoo-1.6.13.jar to $ACSROOT/lib/endorsed
+cp -a  JTattoo-1.6.13.jar $ACSROOT/lib/endorsed
+cd $CWD
+
+echo JTattoo installation done!
+date

--- a/ExtProd/INSTALL/buildTools
+++ b/ExtProd/INSTALL/buildTools
@@ -248,6 +248,10 @@ fi
 # cd ../RTOS
 # ./buildRTOS
 
+# Add java LAF (Look and Feel) color theme for ACS Command Center
+echo  -n "buildJTattoo" 
+./buildJTattoo && echo_success || echo_failure
+
 echo "WARNING: Now log out and login again to make sure that"
 echo "         the environment is re-evaluated!"
 echo " "

--- a/ExtProd/PRODUCTS/extprods.links.txt
+++ b/ExtProd/PRODUCTS/extprods.links.txt
@@ -11,3 +11,4 @@ omniORB-4.2.1-2.tar.bz2 https://downloads.sourceforge.net/project/omniorb/omniOR
 omniORBpy-4.2.1-2.tar.bz2 https://downloads.sourceforge.net/project/omniorb/omniORBpy/omniORBpy-4.2.1/omniORBpy-4.2.1-2.tar.bz2?r=https%3A%2F%2Fsourceforge.net%2Fprojects%2Fomniorb%2Ffiles%2FomniORBpy%2FomniORBpy-4.2.1%2F&ts=1496017150&use_mirror=razaoinfo
 apache-maven-3.2.5-bin.tar.gz http://mirrors.advancedhosters.com/apache/maven/maven-3/3.2.5/binaries/apache-maven-3.2.5-bin.tar.gz
 OpenDDS-3.5.1.tar.gz http://download.ociweb.com/OpenDDS/previous-releases/OpenDDS-3.5.1.tar.gz
+JTattoo-1.6.13.jar http://www.jtattoo.net/downloads/JTattoo-1.6.13.jar

--- a/LGPL/CommonSoftware/acscommandcenter/src/acscommandcenter
+++ b/LGPL/CommonSoftware/acscommandcenter/src/acscommandcenter
@@ -35,4 +35,10 @@
 # Set JVM_GC_LOG_NAME so that acsStartJava will run the JVM printing garbage collector details to file "acscommandcenter.gclog". 
 export JVM_GC_LOG_NAME=acscommandcenter
 
-acsStartJava -noDirectory -noexport -endorsed -D ACS.root=$ACSROOT -D ACS.cdbroot=$ACS_CDB alma.acs.commandcenter.CommandCenter $@
+{ 
+	acsStartJava -noDirectory -noexport -endorsed -D swing.defaultlaf=com.jtattoo.plaf.noire.NoireLookAndFeel -D ACS.root=$ACSROOT -D ACS.cdbroot=$ACS_CDB alma.acs.commandcenter.CommandCenter $@
+} ||
+{ 
+	acsStartJava -noDirectory -noexport -endorsed -D ACS.root=$ACSROOT -D ACS.cdbroot=$ACS_CDB alma.acs.commandcenter.CommandCenter $@
+}
+


### PR DESCRIPTION
add JTattoo .jar file to provide dark color theme for ACS Command Center.

`/alma/ACS-OCT2016/ACSSW/bin/acscommandcenter` will load the "noir"  Look and Feel from this .jar on command line.

BEFORE: 
![acs-before](https://user-images.githubusercontent.com/31044782/80559275-4083b900-8a07-11ea-82ff-f871c9aa3c5f.png)

AFTER
![acs-after](https://user-images.githubusercontent.com/31044782/80559280-437ea980-8a07-11ea-983f-70ad83f8aa55.png)
